### PR TITLE
Fix include directory

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -6,9 +6,9 @@ BASEDIR := $(abspath $(CURDIR)/..)
 PROJECT ?= $(notdir $(BASEDIR))
 PROJECT := $(strip $(PROJECT))
 
-ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
-ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
-ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)])." -s init stop)
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)])." -s init stop)
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)])." -s init stop)
 
 C_SRC_DIR = $(CURDIR)
 C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so


### PR DESCRIPTION
I got the following error while trying to compile this library on OTP 26:

```sh
root@f8e1c9950f45:/app# rebar3 compile
===> Verifying dependencies...
make: Entering directory '/app/c_src'
Error! Failed to eval: io:format("~s/erts-~s/include/", [code:root_dir(), erlang:system_info(version)]).

Error! Failed to eval: io:format("~s", [code:lib_dir(erl_interface, include)]).

cc -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -fPIC -I  -I   -c -o /app/c_src/murmur3.o /app/c_src/murmur3.c
Error! Failed to eval: io:format("~s/erts-~s/include/", [code:root_dir(), erlang:system_info(version)]).

Error! Failed to eval: io:format("~s", [code:lib_dir(erl_interface, include)]).

cc -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -fPIC -I  -I   -c -o /app/c_src/murmur_nif.o /app/c_src/murmur_nif.c
/app/c_src/murmur_nif.c:1:10: fatal error: erl_nif.h: No such file or directory
    1 | #include "erl_nif.h"
      |          ^~~~~~~~~~~
compilation terminated.
make: *** [Makefile:63: /app/c_src/murmur_nif.o] Error 1
make: Leaving directory '/app/c_src'
===> Hook for compile failed!
```

Changing it to the line in the PR seems to have solved it:

```sh
root@6b6b9dbfb186:/app# erl -noshell -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)])." -s init stop; echo
/usr/local/lib/erlang/erts-14.0.2/include/
```